### PR TITLE
Fix setup-cpu.sh

### DIFF
--- a/setup-cpu.sh
+++ b/setup-cpu.sh
@@ -1,4 +1,4 @@
-conda create -n chinese-ocr python=2.7 pip scipy numpy PIL jupyter##运用conda 创建python环境
+conda create -n chinese-ocr python=2.7 pip scipy numpy pillow jupyter ##运用conda 创建python环境
 source activate chinese-ocr
 pip install easydict -i https://pypi.tuna.tsinghua.edu.cn/simple/ ##选择国内源，速度更快
 pip install keras==2.0.8  -i https://pypi.tuna.tsinghua.edu.cn/simple/  


### PR DESCRIPTION
The `setup-cpu.sh` did not work because of wrong shell comment syntax, and `PIL` should be `pillow` instead.